### PR TITLE
fix: added connection pool

### DIFF
--- a/lib/interfaces/mysql-options.interface.ts
+++ b/lib/interfaces/mysql-options.interface.ts
@@ -26,4 +26,5 @@ export interface MysqlModuleOptions {
   dateStrings?: boolean;
   multipleStatements?: boolean;
   localInfile?: boolean;
+  pool?: boolean;
 }

--- a/lib/mysql-core.module.ts
+++ b/lib/mysql-core.module.ts
@@ -124,8 +124,13 @@ export class MysqlCoreModule implements OnApplicationShutdown {
   ): Promise<any> {
     return lastValueFrom(
       defer(async () => {
-        const client = mysql.createConnection(options);
-        return client;
+        if (options.pool === true) {
+          const clientPool = mysql.createPool(options);
+          return clientPool;
+        } else {
+          const client = mysql.createConnection(options);
+          return client;
+        }
       }).pipe(handleRetry(options.retryAttempts, options.retryDelay)),
     );
   }


### PR DESCRIPTION
Added connection pool

example configuration create a connection pool:

```typescript
@Module({
  imports: [
    MysqlModule.forRoot({
        host: 'localhost',
        database: 'test2',
        password: 'root',
        user: 'root',
        port: 3306,  
        waitForConnections: true,
        connectionLimit: 10,
        queueLimit: 0,
        pool: true,
    }),
  ],
})
```